### PR TITLE
Fix: Adjust globe initial zoom and center

### DIFF
--- a/src/config/mapbox.ts
+++ b/src/config/mapbox.ts
@@ -12,8 +12,8 @@ export const MAPBOX_STYLES = {
 
 // Default map settings
 export const DEFAULT_MAP_CONFIG = {
-  center: [0, 30] as [number, number], // Optimal center for visual balance showing Europe, Africa, and Asia
-  zoom: 1.8,
+  center: [0, 0] as [number, number], // Center of the globe
+  zoom: 0.5,
   pitch: 25,
   bearing: 0,
   projection: 'globe' as const,


### PR DESCRIPTION
The initial view of the 3D globe was too zoomed in, not showing the entire Earth. The "reset bearing to north" control also reset to this zoomed-in state.

This change adjusts the default map configuration in `src/config/mapbox.ts`:
- The `zoom` level is reduced from 1.8 to 0.5 to make the entire globe visible within its container.
- The `center` is changed from [0, 30] to [0, 0] for a more neutral, globally centered view.

These changes ensure that both the initial load and the reset functionality provide a view of the entire globe, as requested.